### PR TITLE
Revert "feat(deps): update quay.io/minio/minio docker tag to release.2024-03-03t17-50-39z"

### DIFF
--- a/kubernetes/apps/system/minio/app/helm-release.yaml
+++ b/kubernetes/apps/system/minio/app/helm-release.yaml
@@ -33,7 +33,7 @@ spec:
           main:
             image:
               repository: quay.io/minio/minio
-              tag: RELEASE.2024-03-03T17-50-39Z
+              tag: RELEASE.2024-02-26T09-33-48Z
             args: ["server", "/data", "--console-address", ":9001"]
             envFrom:
               - secretRef:


### PR DESCRIPTION
Reverts larivierec/home-cluster#2988
Broken access to existing buckets