### PR TITLE
Revert "feat(deps): update ghcr.io/koush/scrypted docker tag to v20-jammy-full-v0.99.0"

### DIFF
--- a/kubernetes/apps/home/scrypted/app/helm-release.yaml
+++ b/kubernetes/apps/home/scrypted/app/helm-release.yaml
@@ -39,7 +39,7 @@ spec:
           app:
             image:
               repository: ghcr.io/koush/scrypted
-              tag: 20-jammy-full-v0.99.0
+              tag: 20-jammy-full-v0.98.0
             resources:
               requests:
                 gpu.intel.com/i915: 1


### PR DESCRIPTION
Reverts larivierec/home-cluster#3319
broke