### PR TITLE
Revert "feat(container): update ghcr.io/siderolabs/kubelet docker tag to v1.32.0"

### DIFF
--- a/kubernetes/main/apps/system-upgrade/system-upgrade-controller/ks.yaml
+++ b/kubernetes/main/apps/system-upgrade/system-upgrade-controller/ks.yaml
@@ -43,4 +43,4 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
       TALOS_VERSION: v1.8.3
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-      KUBERNETES_VERSION: v1.32.0
+      KUBERNETES_VERSION: v1.31.4

--- a/kubernetes/main/bootstrap/talos/talconfig.yaml
+++ b/kubernetes/main/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.8.3
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.32.0
+kubernetesVersion: v1.31.4
 
 clusterName: ${clusterName}
 endpoint: https://${clusterEndpointIP}:6443


### PR DESCRIPTION
Reverts larivierec/home-cluster#4494

```bash
Defaulted container "upgrade" out of: upgrade, prepare (init)
automatically detected the lowest Kubernetes version 1.31.4
unsupported upgrade path 1.31->1.32 (from "1.31.4" to "1.32.0")
```