### PR TITLE
Revert "feat(helm)!: Update Helm release snapshot-controller to v4"

### DIFF
--- a/kubernetes/main/apps/kube-system/snapshot-controller/app/helm-release.yaml
+++ b/kubernetes/main/apps/kube-system/snapshot-controller/app/helm-release.yaml
@@ -8,7 +8,7 @@ spec:
   chart:
     spec:
       chart: snapshot-controller
-      version: 4.0.0
+      version: 3.0.6
       sourceRef:
         kind: HelmRepository
         name: piraeus


### PR DESCRIPTION
Reverts larivierec/home-cluster#4489

as discussed on home-k8s, the rook-ceph crds don't include the new version of volumegroup* snapshot crds.
reverting, and pausing until this has been fixed.