### PR TITLE
Revert "feat(container): update image ghcr.io/siderolabs/kubelet ( v1.32.4 → v1.33.0 )"

### DIFF
--- a/bootstrap/talos/talconfig.yaml
+++ b/bootstrap/talos/talconfig.yaml
@@ -3,7 +3,7 @@
 # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
 talosVersion: v1.9.5
 # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-kubernetesVersion: v1.33.0
+kubernetesVersion: v1.32.4
 
 clusterName: ${clusterName}
 endpoint: https://${clusterEndpointIP}:6443

--- a/kubernetes/main/apps/system-upgrade/system-upgrade-controller/ks.yaml
+++ b/kubernetes/main/apps/system-upgrade/system-upgrade-controller/ks.yaml
@@ -43,4 +43,4 @@ spec:
       # renovate: datasource=docker depName=ghcr.io/siderolabs/installer
       TALOS_VERSION: v1.9.5
       # renovate: datasource=docker depName=ghcr.io/siderolabs/kubelet
-      KUBERNETES_VERSION: v1.33.0
+      KUBERNETES_VERSION: v1.32.4


### PR DESCRIPTION
Reverts larivierec/home-cluster#5171

Talosctl supporting 1.33.0 not yet released won't do anything.